### PR TITLE
#168244982 Fixes the click event on the log in and sign up buttons, and replaces placeholder images

### DIFF
--- a/UI/index.css
+++ b/UI/index.css
@@ -151,7 +151,8 @@ body {
 .description img {
     float: right;
     margin-top: -6rem;
-    width: 140px;
+    width: 160px;
+    border-radius: 3%;
 }
 
 .description p {
@@ -179,6 +180,8 @@ body {
 
 #descriptionimg {
     margin-top: -10rem;
+    width: 180px;
+    border-radius: 2%;
 }
 
 .one, .three {

--- a/UI/index.html
+++ b/UI/index.html
@@ -13,14 +13,14 @@
         <div class="intro-panel">
             <div class="buttons">
                 <button id="register-as-mentor">Be a mentor</button>
-                <button id="sign-in-button">Sign In</button>
-                <button class="getStarted" id="sign-up-button">Sign Up</button>
+                <button id="sign-in-button" onclick = "location.href = 'signIn.html'">Sign In</button>
+                <button class="getStarted" id="sign-up-button" onclick = "location.href = 'signUp.html'">Sign Up</button>
             </div>
             <div class="vision">
                 <img src="./images/mentor.jpg" alt="A mentor sitting together with a mentee">
                 <div class="summary">
                     <h1>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</h1>    
-                    <button class="getStarted">Get Started now!</button>
+                    <button class="getStarted" onclick = "location.href = 'signUp.html'">Get Started now!</button>
                 </div>
             </div>
             <div class="subtitles">
@@ -37,7 +37,7 @@
                 <div class="description">
                     <div class="description-div">
                         <p id="describe">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ac auctor augue mauris augue neque gravida in fermentum.</p>
-                        <button class="getStarted">Sign Up & view mentors</button>
+                        <button class="getStarted" onclick = "location.href = 'signUp.html'">Sign Up & view mentors</button>
                     </div>
                     <img id="descriptionimg" src="https://via.placeholder.com/200x200" alt="A picture of a happy mentor">
                 </div>
@@ -65,12 +65,11 @@
         </div>
         <div class="mission">
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ac auctor augue mauris augue neque gravida in fermentum. Ut sem viverra aliquet eget sit amet tellus. Facilisis sed odio morbi quis commodo odio aenean sed adipiscing.</p>
-            <button class="getStarted">Get started now!</button>
+            <button class="getStarted" onclick = "location.href = 'signUp.html'">Get started now!</button>
         </div>
         <footer>
             <span>&copy;Free-Mentors 2019</span>
         </footer>
     </div>
-    <script src="./index.js"></script>
 </body>
 </html>

--- a/UI/index.html
+++ b/UI/index.html
@@ -39,7 +39,7 @@
                         <p id="describe">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ac auctor augue mauris augue neque gravida in fermentum.</p>
                         <button class="getStarted" onclick = "location.href = 'signUp.html'">Sign Up & view mentors</button>
                     </div>
-                    <img id="descriptionimg" src="https://via.placeholder.com/200x200" alt="A picture of a happy mentor">
+                    <img id="descriptionimg" src="./images/all-mentors.jpg" alt="A picture of a happy mentor">
                 </div>
             </div>
             <div class="panel two">
@@ -49,7 +49,7 @@
                 </div>
                 <div class="description">
                     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ac auctor augue mauris augue neque gravida in fermentum.</p>
-                    <img src="https://via.placeholder.com/200x200" alt="A picture depicting an idea">
+                    <img src="./images/sendMentorshipRequest.jpg" alt="A picture depicting an idea">
                 </div>
             </div>
             <div class="panel three">
@@ -59,7 +59,7 @@
                 </div>
                 <div class="description">
                     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ac auctor augue mauris augue neque gravida in fermentum.</p>
-                    <img src="https://via.placeholder.com/200x200" alt="A mentor and a mentee holding a video call">
+                    <img src="./images/mentorshipSession.jpg" alt="A mentor and a mentee holding a video call">
                 </div>
             </div>
         </div>

--- a/UI/index.js
+++ b/UI/index.js
@@ -1,37 +1,37 @@
 const signInButton = document.querySelector('#sign-in-button');
 const getStarted = document.querySelectorAll('.getStarted');
 
-class User {
+let user = {
     constructor(name, surname, email){
         _firstName = name;
         _lastName = surname;
         _email = email;
         isMentor = false;
-    }
+    },
 
     get firstName(){
         return this._firstName;
-    }
+    },
 
     get lastName(){
         return this._lastName;
-    }
+    },
 
     set firstName(newFirstName){
         this._firstName = newFirstName;
-    }
+    },
 
     set lastName(newLastName){
         this._lastName = newLastName;
-    }
+    },
 
     userName(){
         return `${this.firstName} ${this.lastName}`;
-    }
+    },
 
     signIn(){
         location.href = 'signIn.html';
-    }
+    },
 
     signUp(){
         for(let i = 0; i < getStarted.length; i++){
@@ -43,7 +43,7 @@ class User {
 }
 
 signInButton.addEventListener('click', () => {
-    User.signIn();
+    user.signIn();
 });
 
-User.signUp();
+user.signUp();


### PR DESCRIPTION
#### What does this PR do?

It enables the user to navigate to the login and signup forms using the buttons at her disposal on the home page, in order to view mentors and send mentorship requests. 

#### Description of the task to be completed

1. I removed the script tags linking index.html with index.js. I did this to restrict page redirection functionality to HTML.
2. I replaced placeholder images with real images on index.html file.
3. I modified the width of the new images.

#### How should this be manually tested?

1. Click on sign in, sign up and get started now buttons. The sign-in button shall redirect you to the sign-in page, while the signup and get started buttons will redirect you to the signup page.
2. Check the lack of placeholder images all around the home page.

#### Any background context you want to provide?

Not applicable.

#### What are the relevant pivotal tracker stories?

1. A user is not being able to log in and signup from the buttons at her disposal on the home page [#168244982]

2. A user wants an attractive UI without unattractive placeholder images [#168245013]

#### Screenshots (if appropriate)
![replaced placeholders](https://user-images.githubusercontent.com/52489421/64166807-25e14c00-ce48-11e9-8471-07efb4609d9b.JPG)

![signin button should lead you here](https://user-images.githubusercontent.com/52489421/64166851-3b567600-ce48-11e9-8e66-640724f48fc3.JPG)

![signup or get started now buttons should lead you here](https://user-images.githubusercontent.com/52489421/64166854-3c87a300-ce48-11e9-83b6-9bd746d6012f.JPG)
